### PR TITLE
Introduce LRUCache to limit the max memory used by the model

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 jsonpickle = "*"
 kafka-python = "*"
 redis = "*"
+cachetools = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4e633a4d94f5d7e5da73a59e63d286c5e9497bc8b0ca420ea3952409d45ad895"
+            "sha256": "5d6b749cdaaa737699773b9fd5ec63baccd4f6e5aee9b0de38035e5f84e93e47"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,28 +16,37 @@
         ]
     },
     "default": {
+        "cachetools": {
+            "hashes": [
+                "sha256:3796e1de094f0eaca982441c92ce96c68c89cced4cd97721ab297ea4b16db90e",
+                "sha256:c6b07a6ded8c78bf36730b3dc452dfff7d95f2a12a2fed856b1a0cb13ca78c61"
+            ],
+            "index": "pypi",
+            "version": "==4.2.0"
+        },
         "importlib-metadata": {
             "hashes": [
-                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
-                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
+                "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed",
+                "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"
             ],
-            "version": "==1.7.0"
+            "markers": "python_version < '3.8'",
+            "version": "==3.3.0"
         },
         "jsonpickle": {
             "hashes": [
-                "sha256:8919c166bac0574e3d74425c7559434062002d9dfc0ac2afa6dc746ba4a19439",
-                "sha256:e8d4b7cd0bd6826001a74377df1079a76ad8bae0f909282de2554164c837c8ba"
+                "sha256:2ac5863099864c63d7f0c367af5e512c94f3384977dd367f2eae5f2303f7b92c",
+                "sha256:c9b99b28a9e6a3043ec993552db79f4389da11afcb1d0246d93c79f4b5e64062"
             ],
             "index": "pypi",
-            "version": "==1.4.1"
+            "version": "==1.4.2"
         },
         "kafka-python": {
             "hashes": [
-                "sha256:513431184ecd08e706ca53421ff23e269fc052374084b45b49640419564dd704",
-                "sha256:e59ad42dec8c7d54e3fbba0c1f8b54c44d92a3392d88242962d0c29803f2f6f8"
+                "sha256:04dfe7fea2b63726cd6f3e79a2d86e709d608d74406638c5da33a01d45a9d7e3",
+                "sha256:2d92418c7cb1c298fa6c7f0fb3519b520d0d7526ac6cb7ae2a4fc65a51a94b6e"
             ],
             "index": "pypi",
-            "version": "==2.0.1"
+            "version": "==2.0.2"
         },
         "redis": {
             "hashes": [
@@ -47,12 +56,22 @@
             "index": "pypi",
             "version": "==3.5.3"
         },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.7.4.3"
+        },
         "zipp": {
             "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
+                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
             ],
-            "version": "==3.1.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.0"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,11 +26,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed",
-                "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"
+                "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771",
+                "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.3.0"
+            "version": "==3.4.0"
         },
         "jsonpickle": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Our project welcomes external contributions. Please refer to [CONTRIBUTING.md](C
 
 ##### v0.*.*
 * Decrease memory footprint of the main data structures.
+* Added `max_size` option to limit the number of tracked clusters.
+* Changed cluster identifier type from str to int
 
 ##### v0.8.6
 * Added `extra_delimiters` configuration option to Drain  

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Our project welcomes external contributions. Please refer to [CONTRIBUTING.md](C
 
 ## Change Log
 
+##### v0.*.*
+* Decrease memory footprint of the main data structures.
+
 ##### v0.8.6
 * Added `extra_delimiters` configuration option to Drain  
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Available parameters are:
 - `[DRAIN]/sim_th` - similarity threshold (default 0.4)
 - `[DRAIN]/depth` - depth of all leaf nodes (default 4)
 - `[DRAIN]/max_children` - max number of children of an internal node (default 100)
+- `[DRAIN]/max_clusters` - max number of tracked clusters (unlimited by default). When this number is reached, model starts replacing old clusters with a new ones according to the LRU cache eviction policy.
 - `[DRAIN]/extra_delimiters` - delimiters to apply when splitting log message into words (in addition to whitespace) (default none).
     Format is a Python list e.g. `['_', ':']`.
 - `[MASKING]/masking` - parameters masking - in json format (default "")

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Our project welcomes external contributions. Please refer to [CONTRIBUTING.md](C
 
 ##### v0.*.*
 * Decrease memory footprint of the main data structures.
-* Added `max_size` option to limit the number of tracked clusters.
+* Added `max_clusters` option to limit the number of tracked clusters.
 * Changed cluster identifier type from str to int
 
 ##### v0.8.6

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A possible Drain3 use case in this blog post: [Use open source Drain3 log-templa
 - **Streaming**. Support feeding Drain with messages one-be-one.
 - **Masking**. Replace some message parts (e.g numbers, IPs, emails) with wildcards. This improves the accuracy of template mining.
 - **Packaging**. As a pip package. 
+- **Memory efficiency**. Decrease the memory footprint of internal data structures and introduce cache to control max memory consumed.
 
 #### Expected Input and Output
 
@@ -151,6 +152,9 @@ to change Kafka endpoint (default is `localhost:9092`).
 
 Drain3 persistence modes can be easily extended to another medium / database by 
 inheriting the [PersistenceHandler](drain3/persistence_handler.py) class.
+
+## Memory efficiency
+This feature limits the max memory used by the model. It is particularly important for large and possibly unbounded log streams. This feature is controlled by the `max_clusters​` parameter, which sets the max number of clusters/templates trarcked by the model. When the limit is reached, new templates start to replace the old ones according to the Least Recently Used (LRU) eviction policy. This makes the model adapt quickly to the most recent templates in the log stream. 
 
 
 ## Installation

--- a/drain3/template_miner.py
+++ b/drain3/template_miner.py
@@ -46,6 +46,7 @@ class TemplateMiner:
             sim_th=self.config.getfloat('DRAIN', 'sim_th', fallback=0.4),
             depth=self.config.getint('DRAIN', 'depth', fallback=4),
             max_children=self.config.getint('DRAIN', 'max_children', fallback=100),
+            max_clusters=self.config.getint('DRAIN', 'max_clusters', fallback=None),
             extra_delimiters=extra_delimiters,
             profiler=self.profiler
         )

--- a/examples/drain3.ini
+++ b/examples/drain3.ini
@@ -17,6 +17,7 @@ masking = [
 sim_th = 0.4
 depth = 4
 max_children = 100
+max_clusters = 1024
 extra_delimiters = ["_"]
 
 [PROFILING]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonpickle==1.4.1
 kafka-python==2.0.1
 redis==3.5.3
+cachetools==4.2.0

--- a/tests/test_drain.py
+++ b/tests/test_drain.py
@@ -74,3 +74,42 @@ class DrainTest(unittest.TestCase):
 
         self.assertListEqual(list(map(str.strip, expected)), actual)
         self.assertEqual(8, model.get_total_cluster_size())
+
+    def test_max_size(self):
+        """Verify model respects the max_size option.
+        
+        Key difference between this tests and `test_add_log_message` is that
+        with `max_size` set to 1 model is capable of keeping track of a single
+        cluster at a time. Consequently, when log stream switched form the first
+        format to a second format and back model doesn't recognize it and
+        returnes a new template with no slots.
+        """
+        model = Drain(max_size=1)
+        entries = str.splitlines(
+            """
+            Dec 10 07:07:38 LabSZ sshd[24206]: input_userauth_request: invalid user test9 [preauth]
+            Dec 10 07:08:28 LabSZ sshd[24208]: input_userauth_request: invalid user webmaster [preauth]
+            Dec 10 09:12:32 LabSZ sshd[24490]: Failed password for invalid user ftpuser from 0.0.0.0 port 62891 ssh2
+            Dec 10 09:12:35 LabSZ sshd[24492]: Failed password for invalid user pi from 0.0.0.0 port 49289 ssh2
+            Dec 10 09:12:44 LabSZ sshd[24501]: Failed password for invalid user ftpuser from 0.0.0.0 port 60836 ssh2
+            Dec 10 07:28:03 LabSZ sshd[24245]: input_userauth_request: invalid user pgadmin [preauth]
+            """
+        )
+        expected = str.splitlines(
+            """
+            Dec 10 07:07:38 LabSZ sshd[24206]: input_userauth_request: invalid user test9 [preauth]
+            Dec 10 <*> LabSZ <*> input_userauth_request: invalid user <*> [preauth]
+            Dec 10 09:12:32 LabSZ sshd[24490]: Failed password for invalid user ftpuser from 0.0.0.0 port 62891 ssh2
+            Dec 10 <*> LabSZ <*> Failed password for invalid user <*> from 0.0.0.0 port <*> ssh2
+            Dec 10 <*> LabSZ <*> Failed password for invalid user <*> from 0.0.0.0 port <*> ssh2
+            Dec 10 07:28:03 LabSZ sshd[24245]: input_userauth_request: invalid user pgadmin [preauth]
+            """
+        )
+        actual = []
+
+        for entry in entries:
+            cluster, change_type = model.add_log_message(entry)
+            actual.append(cluster.get_template())
+
+        self.assertListEqual(list(map(str.strip, expected)), actual)
+        self.assertEqual(1, model.get_total_cluster_size())

--- a/tests/test_drain.py
+++ b/tests/test_drain.py
@@ -75,16 +75,16 @@ class DrainTest(unittest.TestCase):
         self.assertListEqual(list(map(str.strip, expected)), actual)
         self.assertEqual(8, model.get_total_cluster_size())
 
-    def test_max_size(self):
-        """Verify model respects the max_size option.
+    def test_max_clusters(self):
+        """Verify model respects the max_clusters option.
         
         Key difference between this tests and `test_add_log_message` is that
-        with `max_size` set to 1 model is capable of keeping track of a single
+        with `max_clusters` set to 1 model is capable of keeping track of a single
         cluster at a time. Consequently, when log stream switched form the first
         format to a second format and back model doesn't recognize it and
         returnes a new template with no slots.
         """
-        model = Drain(max_size=1)
+        model = Drain(max_clusters=1)
         entries = str.splitlines(
             """
             Dec 10 07:07:38 LabSZ sshd[24206]: input_userauth_request: invalid user test9 [preauth]


### PR DESCRIPTION
When experimenting with Drain3 I noticed that with long log streams its internal data structures can grow until process gets killed with Out Of Memory error. 

After investigating this problem I realized that while max depth constraint works perfectly for keeping the three shallow and balanced, leaf nodes hold reference to log clusters and there are no constraints at all. This means that with a long log streams the number of clusters can grow until there is no more memory left. 

This PR solves this problem by adding a LRU cache for keeping track of log clusters. With this change one can set `max_children` as well as `max_size` (I could rename it to `max_clusters`) to control the memory requirements of the model.

In my experiments I saw it complements the fixed depth and makes the algorithm behave stable even when working with long log streams.