### PR TITLE
Added support for accurate log message params extraction

### DIFF
--- a/drain3/masking.py
+++ b/drain3/masking.py
@@ -4,8 +4,8 @@ Author      : Moshik Hershcovitch
 Author_email: moshikh@il.ibm.com
 License     : MIT
 """
-import re
 import abc
+import re
 from typing import Collection
 
 
@@ -47,7 +47,8 @@ RegexMaskingInstruction = MaskingInstruction
 
 class LogMasker:
 
-    def __init__(self, masking_instructions: Collection[AbstractMaskingInstruction], mask_prefix: str, mask_suffix: str):
+    def __init__(self, masking_instructions: Collection[AbstractMaskingInstruction],
+                 mask_prefix: str, mask_suffix: str):
         self.mask_prefix = mask_prefix
         self.mask_suffix = mask_suffix
         self.masking_instructions = masking_instructions

--- a/drain3/masking.py
+++ b/drain3/masking.py
@@ -6,7 +6,7 @@ License     : MIT
 """
 import abc
 import re
-from typing import Collection
+from typing import Collection, Optional
 
 
 class AbstractMaskingInstruction(abc.ABC):
@@ -66,8 +66,8 @@ class LogMasker:
     def mask_names(self) -> Collection[str]:
         return self.mask_name_to_instructions.keys()
 
-    def instructions_by_mask_name(self, mask_name: str) -> Collection[AbstractMaskingInstruction]:
-        return self.mask_name_to_instructions[mask_name]
+    def instructions_by_mask_name(self, mask_name: str) -> Optional[Collection[AbstractMaskingInstruction]]:
+        return self.mask_name_to_instructions.get(mask_name)
 
 # Some masking examples
 # ---------------------

--- a/drain3/masking.py
+++ b/drain3/masking.py
@@ -1,35 +1,72 @@
 """
-Description : This file implements the persist/restore from Kafka
+Description : This file implements the masking using user-provided patterns
 Author      : Moshik Hershcovitch
 Author_email: moshikh@il.ibm.com
 License     : MIT
 """
-import logging
 import re
-from typing import List
+import abc
+from typing import Collection
 
-logger = logging.getLogger(__name__)
 
+class AbstractMaskingInstruction(abc.ABC):
 
-class MaskingInstruction:
-    def __init__(self, regex_pattern: str, mask_with: str):
-        self.regex_pattern = regex_pattern
+    def __init__(self, mask_with: str):
         self.mask_with = mask_with
-        self.regex = re.compile(regex_pattern)
+
+    @abc.abstractmethod
+    def mask(self, content: str, mask_prefix: str, mask_suffix: str) -> str:
+        """
+        Mask content according to this instruction and return the result.
+
+        :param content: text to apply masking to
+        :param mask_prefix: the prefix of any masks inserted
+        :param mask_suffix: the suffix of any masks inserted
+        """
+        pass
 
 
-class RegexMasker:
-    def __init__(self, masking_instructions: List[MaskingInstruction], mask_prefix: str, mask_suffix: str):
+class MaskingInstruction(AbstractMaskingInstruction):
+
+    def __init__(self, pattern: str, mask_with: str):
+        super().__init__(mask_with)
+        self.regex = re.compile(pattern)
+
+    @property
+    def pattern(self):
+        return self.regex.pattern
+
+    def mask(self, content: str, mask_prefix: str, mask_suffix: str) -> str:
+        mask = mask_prefix + self.mask_with + mask_suffix
+        return self.regex.sub(mask, content)
+
+
+# Alias for `MaskingInstruction`.
+RegexMaskingInstruction = MaskingInstruction
+
+
+class LogMasker:
+
+    def __init__(self, masking_instructions: Collection[AbstractMaskingInstruction], mask_prefix: str, mask_suffix: str):
         self.mask_prefix = mask_prefix
         self.mask_suffix = mask_suffix
         self.masking_instructions = masking_instructions
-
-    def mask(self, content: str):
+        self.mask_name_to_instructions = {}
         for mi in self.masking_instructions:
-            # content = re.sub(mi.regex, mi.mask_with_wrapped, content)
-            content = mi.regex.sub(self.mask_prefix + mi.mask_with + self.mask_suffix, content)
+            self.mask_name_to_instructions.setdefault(mi.mask_with, [])
+            self.mask_name_to_instructions[mi.mask_with].append(mi)
+
+    def mask(self, content: str) -> str:
+        for mi in self.masking_instructions:
+            content = mi.mask(content, self.mask_prefix, self.mask_suffix)
         return content
 
+    @property
+    def mask_names(self) -> Collection[str]:
+        return self.mask_name_to_instructions.keys()
+
+    def instructions_by_mask_name(self, mask_name: str) -> Collection[AbstractMaskingInstruction]:
+        return self.mask_name_to_instructions[mask_name]
 
 # Some masking examples
 # ---------------------
@@ -44,14 +81,3 @@ class RegexMasker:
 #    MaskingInstruction(r'((?<=[^A-Za-z0-9])|^)([\-\+]?\d+)((?=[^A-Za-z0-9])|$)', "NUM"),
 #    MaskingInstruction(r'(?<=executed cmd )(".+?")', "CMD"),
 # ]
-
-
-class LogMasker:
-    def __init__(self, masking_instructions: List[MaskingInstruction], mask_prefix: str, mask_suffix: str):
-        self.masker = RegexMasker(masking_instructions, mask_prefix, mask_suffix)
-
-    def mask(self, content: str):
-        if self.masker is not None:
-            return self.masker.mask(content)
-        else:
-            return content

--- a/drain3/masking.py
+++ b/drain3/masking.py
@@ -67,7 +67,7 @@ class LogMasker:
         return self.mask_name_to_instructions.keys()
 
     def instructions_by_mask_name(self, mask_name: str) -> Optional[Collection[AbstractMaskingInstruction]]:
-        return self.mask_name_to_instructions.get(mask_name)
+        return self.mask_name_to_instructions.get(mask_name) or []
 
 # Some masking examples
 # ---------------------

--- a/drain3/template_miner.py
+++ b/drain3/template_miner.py
@@ -252,7 +252,7 @@ class TemplateMiner:
             allowed_patterns = []
             if exact_matching:
                 # get all possible regex patterns from masking instructions that match this mask name
-                masking_instructions = self.masker.instructions_by_mask_name(_mask_name) or []
+                masking_instructions = self.masker.instructions_by_mask_name(_mask_name)
                 for mi in masking_instructions:
                     # MaskingInstruction may already contain named groups.
                     # We replace group names in those named groups, to avoid conflicts due to duplicate names.

--- a/drain3/template_miner.py
+++ b/drain3/template_miner.py
@@ -217,19 +217,25 @@ class TemplateMiner:
         for delimiter in self.config.drain_extra_delimiters:
             log_message = re.sub(delimiter, " ", log_message)
 
-        template_regex, param_group_name_to_mask_name = self._get_template_parameter_extraction_regex(log_template,
-                                                                                                      exact_matching)
+        template_regex, param_group_name_to_mask_name = self._get_template_parameter_extraction_regex(
+            log_template, exact_matching)
 
         # Parameters are represented by specific named groups inside template_regex.
         parameter_match = re.match(template_regex, log_message)
+
+        # log template does not match template
         if not parameter_match:
             return None
-        parameter_details_list = []
+
+        # create list of extracted parameters
+        extracted_parameters = []
         for group_name, parameter in parameter_match.groupdict().items():
             if group_name in param_group_name_to_mask_name:
-                parameter_details_list.append(ExtractedParameter(parameter, param_group_name_to_mask_name[group_name]))
+                mask_name = param_group_name_to_mask_name[group_name]
+                extracted_parameter = ExtractedParameter(parameter, mask_name)
+                extracted_parameters.append(extracted_parameter)
 
-        return parameter_details_list
+        return extracted_parameters
 
     @cachedmethod(lambda self: self.parameter_extraction_cache)
     def _get_template_parameter_extraction_regex(self, log_template: str, exact_matching: bool):

--- a/drain3/template_miner.py
+++ b/drain3/template_miner.py
@@ -256,8 +256,13 @@ class TemplateMiner:
                 for mi in masking_instructions:
                     # MaskingInstruction may already contain named groups.
                     # We replace group names in those named groups, to avoid conflicts due to duplicate names.
-                    mi_groups = mi.regex.groupindex.keys()
-                    pattern = mi.pattern
+                    if hasattr(mi, 'regex'):
+                        mi_groups = mi.regex.groupindex.keys()
+                        pattern = mi.pattern
+                    else:
+                        # non regex masking instructions - support only non-exact matching
+                        mi_groups = []
+                        pattern = ".+?"
 
                     for group_name in mi_groups:
                         param_group_name = get_next_param_name()

--- a/drain3/template_miner.py
+++ b/drain3/template_miner.py
@@ -9,12 +9,13 @@ import logging
 import re
 import time
 import zlib
+from typing import Optional, List, NamedTuple
 
 import jsonpickle
-from cachetools import LRUCache
+from cachetools import LRUCache, cachedmethod
 
 from drain3.drain import Drain, LogCluster
-from drain3.masking import LogMasker
+from drain3.masking import LogMasker, MaskingInstruction
 from drain3.persistence_handler import PersistenceHandler
 from drain3.simple_profiler import SimpleProfiler, NullProfiler, Profiler
 from drain3.template_miner_config import TemplateMinerConfig
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 config_filename = 'drain3.ini'
 
+ExtractedParameter = NamedTuple("ExtractedParameter", [("value", str), ("mask_name", str)])
 
 class TemplateMiner:
 
@@ -62,9 +64,11 @@ class TemplateMiner:
             parametrize_numeric_tokens=self.config.parametrize_numeric_tokens
         )
         self.masker = LogMasker(self.config.masking_instructions, self.config.mask_prefix, self.config.mask_suffix)
+        self.parameter_extraction_cache = LRUCache(self.config.parameter_extraction_cache_capacity)
         self.last_save_time = time.time()
         if persistence_handler is not None:
             self.load_state()
+
 
     def load_state(self):
         logger.info("Checking for saved state")
@@ -170,24 +174,119 @@ class TemplateMiner:
         matched_cluster = self.drain.match(masked_content, full_search_strategy)
         return matched_cluster
 
-    def get_parameter_list(self, log_template: str, content: str):
-        escaped_prefix = re.escape(self.config.mask_prefix)
-        escaped_suffix = re.escape(self.config.mask_suffix)
-        template_regex = re.sub(escaped_prefix + r".+?" + escaped_suffix, self.drain.param_str, log_template)
-        if self.drain.param_str not in template_regex:
+    def get_parameter_list(self, log_template: str, log_message: str) -> List[str]:
+        """
+        Extract parameters from a log message according to a provided template that was generated
+        by calling `add_log_message()`.
+
+        Is is preferable to use extract_parameters.
+
+        :param log_template: log template corresponding to the log message
+        :param log_message: log message to extract parameters from
+        :return: An ordered list of parameter values present in the log message.
+        """
+
+        extracted_parameters = self.extract_parameters(log_template, log_message, exact_matching=False)
+        if not extracted_parameters:
             return []
-        template_regex = re.escape(template_regex)
-        template_regex = re.sub(r'\\ +', r'\\s+', template_regex)
-        template_regex = "^" + template_regex.replace(escaped_prefix + r"\*" + escaped_suffix, "(.*?)") + "$"
+        return [parameter.value for parameter in extracted_parameters]
+
+    def extract_parameters(self, log_template: str, log_message: str, exact_matching: bool = True) -> Optional[List[ExtractedParameter]]:
+        """
+        Extract parameters from a log message according to a provided template that was generated
+        by calling `add_log_message()`.
+
+        For most accurate results, it is recommended that
+        - each `MaskingInstruction` has a unique `mask_with` value,
+        - no `MaskingInstruction` has a `mask_with` value of `*`,
+        - the regex-patterns of `MaskingInstruction` do not use unnamed backreferences;
+          instead use backreferences to named groups e.g. `(?P=some-name)`.
+
+        :param log_template: log template corresponding to the log message
+        :param log_message: log message to extract parameters from
+        :param exact_matching: whether to apply the correct masking-patterns to match parameters, or try to approximate;
+            disabling exact_matching may be faster but may lead to situations in which parameters
+            are wrongly identified.
+        :return: A ordered list of ExtractedParameter for the log message
+            or None if log_message does not correspond to log_template.
+        """
 
         for delimiter in self.config.drain_extra_delimiters:
-            content = re.sub(delimiter, ' ', content)
-        parameter_list = re.findall(template_regex, content)
-        parameter_list = parameter_list[0] if parameter_list else ()
-        parameter_list = list(parameter_list) if isinstance(parameter_list, tuple) else [parameter_list]
+            log_message = re.sub(delimiter, " ", log_message)
 
-        def is_mask(p: str):
-            return p.startswith(self.config.mask_prefix) and p.endswith(self.config.mask_suffix)
+        template_regex, param_group_name_to_mask_name = self._get_template_parameter_extraction_regex(log_template, exact_matching)
 
-        parameter_list = [p for p in list(parameter_list) if not is_mask(p)]
-        return parameter_list
+        # Parameters are represented by specific named groups inside template_regex.
+        parameter_match = re.match(template_regex, log_message)
+        if not parameter_match:
+            return None
+        parameter_details_list = []
+        for group_name, parameter in parameter_match.groupdict().items():
+            if group_name in param_group_name_to_mask_name:
+                parameter_details_list.append(ExtractedParameter(parameter, param_group_name_to_mask_name[group_name]))
+
+        return parameter_details_list
+
+    @cachedmethod(lambda self: self.parameter_extraction_cache)
+    def _get_template_parameter_extraction_regex(self, log_template: str, exact_matching: bool):
+        param_group_name_to_mask_name = dict()
+        param_name_counter = [0]
+
+        def get_next_param_name():
+            param_group_name = "p_" + str(param_name_counter[0])
+            param_name_counter[0] += 1
+            return param_group_name
+
+        # Create a named group with the respective patterns for the given mask-name.
+        def create_capture_regex(_mask_name):
+            allowed_patterns = []
+            if exact_matching and _mask_name in self.masker.mask_names:
+                for mi in self.masker.instructions_by_mask_name(_mask_name):
+                    # MaskingInstruction may already contain named groups.
+                    # We replace group names in those named groups,
+                    # to avoid conflicts due to duplicate names.
+                    mi_groups = mi.regex.groupindex.keys()
+                    pattern = mi.pattern
+
+                    for group_name in mi_groups:
+                        param_group_name = get_next_param_name()
+
+                        def replace_captured_param_name(param_pattern):
+                            _search_str = param_pattern.format(group_name)
+                            _replace_str = param_pattern.format(param_group_name)
+                            return pattern.replace(_search_str, _replace_str)
+
+                        pattern = replace_captured_param_name("(?P={}")
+                        pattern = replace_captured_param_name("(?P<{}>")
+                    pattern = re.sub(r"\\(?!0)\d{1,2}", r"(?:.+?)", pattern)
+                    allowed_patterns.append(pattern)
+            if _mask_name == "*" or not exact_matching:
+                allowed_patterns.append(r".+?")
+            # Give each capture group a unique name to avoid conflicts.
+            param_group_name = get_next_param_name()
+            param_group_name_to_mask_name[param_group_name] = _mask_name
+            joined_patterns = "|".join(allowed_patterns)
+            capture_regex = "(?P<{}>{})".format(param_group_name, joined_patterns)
+            return capture_regex
+
+        # For every mask in the template, replace it with a named group of all
+        # possible masking-patterns it could represent (in order).
+        mask_names = set(self.masker.mask_names)
+        mask_names.add("*")
+        escaped_prefix = re.escape(self.masker.mask_prefix)
+        escaped_suffix = re.escape(self.masker.mask_suffix)
+        template_regex = re.escape(log_template)
+        for mask_name in mask_names:
+            search_str = escaped_prefix + re.escape(mask_name) + escaped_suffix
+            while True:
+                rep_str = create_capture_regex(mask_name)
+                # Replace one-by-one to get a new param group name for each replacement.
+                template_regex_new = template_regex.replace(search_str, rep_str, 1)
+                # Break when all replaces for this mask are done.
+                if template_regex_new == template_regex:
+                    break
+                template_regex = template_regex_new
+
+        template_regex = re.sub(r"\\ ", r"\\s+", template_regex)
+        template_regex = "^" + template_regex + "$"
+        return template_regex, param_group_name_to_mask_name

--- a/drain3/template_miner.py
+++ b/drain3/template_miner.py
@@ -15,7 +15,7 @@ import jsonpickle
 from cachetools import LRUCache, cachedmethod
 
 from drain3.drain import Drain, LogCluster
-from drain3.masking import LogMasker, MaskingInstruction
+from drain3.masking import LogMasker
 from drain3.persistence_handler import PersistenceHandler
 from drain3.simple_profiler import SimpleProfiler, NullProfiler, Profiler
 from drain3.template_miner_config import TemplateMinerConfig
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 config_filename = 'drain3.ini'
 
 ExtractedParameter = NamedTuple("ExtractedParameter", [("value", str), ("mask_name", str)])
+
 
 class TemplateMiner:
 
@@ -68,7 +69,6 @@ class TemplateMiner:
         self.last_save_time = time.time()
         if persistence_handler is not None:
             self.load_state()
-
 
     def load_state(self):
         logger.info("Checking for saved state")
@@ -179,7 +179,7 @@ class TemplateMiner:
         Extract parameters from a log message according to a provided template that was generated
         by calling `add_log_message()`.
 
-        Is is preferable to use extract_parameters.
+        This function is deprecated. Please use extract_parameters instead.
 
         :param log_template: log template corresponding to the log message
         :param log_message: log message to extract parameters from
@@ -191,16 +191,19 @@ class TemplateMiner:
             return []
         return [parameter.value for parameter in extracted_parameters]
 
-    def extract_parameters(self, log_template: str, log_message: str, exact_matching: bool = True) -> Optional[List[ExtractedParameter]]:
+    def extract_parameters(self,
+                           log_template: str,
+                           log_message: str,
+                           exact_matching: bool = True) -> Optional[List[ExtractedParameter]]:
         """
         Extract parameters from a log message according to a provided template that was generated
         by calling `add_log_message()`.
 
         For most accurate results, it is recommended that
-        - each `MaskingInstruction` has a unique `mask_with` value,
-        - no `MaskingInstruction` has a `mask_with` value of `*`,
-        - the regex-patterns of `MaskingInstruction` do not use unnamed backreferences;
-          instead use backreferences to named groups e.g. `(?P=some-name)`.
+        - Each `MaskingInstruction` has a unique `mask_with` value,
+        - No `MaskingInstruction` has a `mask_with` value of `*`,
+        - The regex-patterns of `MaskingInstruction` do not use unnamed back-references;
+          instead use back-references to named groups e.g. `(?P=some-name)`.
 
         :param log_template: log template corresponding to the log message
         :param log_message: log message to extract parameters from
@@ -214,7 +217,8 @@ class TemplateMiner:
         for delimiter in self.config.drain_extra_delimiters:
             log_message = re.sub(delimiter, " ", log_message)
 
-        template_regex, param_group_name_to_mask_name = self._get_template_parameter_extraction_regex(log_template, exact_matching)
+        template_regex, param_group_name_to_mask_name = self._get_template_parameter_extraction_regex(log_template,
+                                                                                                      exact_matching)
 
         # Parameters are represented by specific named groups inside template_regex.
         parameter_match = re.match(template_regex, log_message)

--- a/drain3/template_miner_config.py
+++ b/drain3/template_miner_config.py
@@ -65,7 +65,8 @@ class TemplateMinerConfig:
                                               fallback=str(self.masking_instructions))
         self.mask_prefix = parser.get(section_masking, 'mask_prefix', fallback=self.mask_prefix)
         self.mask_suffix = parser.get(section_masking, 'mask_suffix', fallback=self.mask_suffix)
-        self.parameter_extraction_cache_capacity = parser.get(section_masking, 'parameter_extraction_cache_capacity', fallback=self.parameter_extraction_cache_capacity)
+        self.parameter_extraction_cache_capacity = parser.get(section_masking, 'parameter_extraction_cache_capacity',
+                                                              fallback=self.parameter_extraction_cache_capacity)
 
         masking_instructions = []
         masking_list = json.loads(masking_instructions_str)

--- a/drain3/template_miner_config.py
+++ b/drain3/template_miner_config.py
@@ -22,6 +22,7 @@ class TemplateMinerConfig:
         self.masking_instructions = []
         self.mask_prefix = "<"
         self.mask_suffix = ">"
+        self.parameter_extraction_cache_capacity = 3000
         self.parametrize_numeric_tokens = True
 
     def load(self, config_filename: str):
@@ -64,6 +65,7 @@ class TemplateMinerConfig:
                                               fallback=str(self.masking_instructions))
         self.mask_prefix = parser.get(section_masking, 'mask_prefix', fallback=self.mask_prefix)
         self.mask_suffix = parser.get(section_masking, 'mask_suffix', fallback=self.mask_suffix)
+        self.parameter_extraction_cache_capacity = parser.get(section_masking, 'parameter_extraction_cache_capacity', fallback=self.parameter_extraction_cache_capacity)
 
         masking_instructions = []
         masking_list = json.loads(masking_instructions_str)

--- a/examples/drain_stdin_demo.py
+++ b/examples/drain_stdin_demo.py
@@ -57,7 +57,7 @@ while True:
     result_json = json.dumps(result)
     print(result_json)
     template = result["template_mined"]
-    params = template_miner.get_parameter_list(template, log_line)
+    params = template_miner.extract_parameters(template, log_line)
     print("Parameters: " + str(params))
 
 print("Training done. Mined clusters:")

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,12 +1,34 @@
 import unittest
 
-from drain3.masking import MaskingInstruction, RegexMasker
+from drain3.masking import MaskingInstruction, LogMasker
 
 
 class MaskingTest(unittest.TestCase):
-    def test(self):
+
+    def test_instructions_by_mask_name(self):
+        instructions = []
+        a = MaskingInstruction(r"a", "1")
+        instructions.append(a)
+        b = MaskingInstruction(r"b", "1")
+        instructions.append(b)
+        c = MaskingInstruction(r"c", "2")
+        instructions.append(c)
+        d = MaskingInstruction(r"d", "3")
+        instructions.append(d)
+        x = MaskingInstruction(r"x", "something else")
+        instructions.append(x)
+        y = MaskingInstruction(r"y", "something else")
+        instructions.append(y)
+        masker = LogMasker(instructions, "", "")
+        self.assertCountEqual(["1", "2", "3", "something else"], masker.mask_names)
+        self.assertCountEqual([a, b], masker.instructions_by_mask_name("1"))
+        self.assertCountEqual([c], masker.instructions_by_mask_name("2"))
+        self.assertCountEqual([d], masker.instructions_by_mask_name("3"))
+        self.assertCountEqual([x, y], masker.instructions_by_mask_name("something else"))
+
+    def test_mask(self):
         s = "D9 test 999 888 1A ccc 3"
-        mi = MaskingInstruction(r'((?<=[^A-Za-z0-9])|^)([\-\+]?\d+)((?=[^A-Za-z0-9])|$)', "NUM")
-        rm = RegexMasker([mi], "<!", "!>")
-        masked = rm.mask(s)
+        mi = MaskingInstruction(r"((?<=[^A-Za-z0-9])|^)([\-\+]?\d+)((?=[^A-Za-z0-9])|$)", "NUM")
+        masker = LogMasker([mi], "<!", "!>")
+        masked = masker.mask(s)
         self.assertEqual("D9 test <!NUM!> <!NUM!> 1A ccc <!NUM!>", masked)

--- a/tests/test_template_miner.py
+++ b/tests/test_template_miner.py
@@ -72,7 +72,8 @@ class TemplateMinerTest(unittest.TestCase):
             print(f"msg: {msg}")
             res = template_miner.add_log_message(msg)
             print(f"result: {res}")
-            extracted_parameters = template_miner.extract_parameters(res["template_mined"], msg, exact_matching=exact_matching)
+            extracted_parameters = template_miner.extract_parameters(res["template_mined"], msg,
+                                                                     exact_matching=exact_matching)
             self.assertIsNotNone(extracted_parameters)
             params = [parameter.value for parameter in extracted_parameters]
             print(f"params: {params}")
@@ -296,8 +297,10 @@ class TemplateMinerTest(unittest.TestCase):
                     self.assertIsNone(extracted_parameters)
                 else:
                     self.assertIsNotNone(extracted_parameters)
-                    self.assertListEqual([parameter.value for parameter in extracted_parameters], expected_parameters)
-                    self.assertListEqual([parameter.mask_name for parameter in extracted_parameters], expected_mask_names)
+                    self.assertListEqual([parameter.value for parameter in extracted_parameters],
+                                         expected_parameters)
+                    self.assertListEqual([parameter.mask_name for parameter in extracted_parameters],
+                                         expected_mask_names)
 
     def test_match_only(self):
         config = TemplateMinerConfig()

--- a/tests/test_template_miner.py
+++ b/tests/test_template_miner.py
@@ -58,30 +58,246 @@ class TemplateMinerTest(unittest.TestCase):
         print(template_miner2.add_log_message("hello yyy"))
         print(template_miner2.add_log_message("goodbye ABC"))
 
-    def test_get_param_list(self):
+    def test_extract_parameters(self):
         config = TemplateMinerConfig()
         mi = MaskingInstruction("((?<=[^A-Za-z0-9])|^)([\\-\\+]?\\d+)((?=[^A-Za-z0-9])|$)", "NUM")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"multiple words", "WORDS")
         config.masking_instructions.append(mi)
         config.mask_prefix = "[:"
         config.mask_suffix = ":]"
         template_miner = TemplateMiner(None, config)
 
-        def add_and_test(msg, expected_params):
+        def add_and_test(msg, expected_params, exact_matching=False):
             print(f"msg: {msg}")
             res = template_miner.add_log_message(msg)
             print(f"result: {res}")
-            params = template_miner.get_parameter_list(res["template_mined"], msg)
+            extracted_parameters = template_miner.extract_parameters(res["template_mined"], msg, exact_matching=exact_matching)
+            self.assertIsNotNone(extracted_parameters)
+            params = [parameter.value for parameter in extracted_parameters]
             print(f"params: {params}")
             self.assertListEqual(params, expected_params)
 
         add_and_test("hello", [])
         add_and_test("hello ABC", [])
         add_and_test("hello BCD", ["BCD"])
+        add_and_test("hello    BCD", ["BCD"])
+        add_and_test("hello\tBCD", ["BCD"])
         add_and_test("request took 123 ms", ["123"])
         add_and_test("file saved [test.xml]", [])
         add_and_test("new order received: [:xyz:]", [])
         add_and_test("order type: new, order priority:3", ["3"])
         add_and_test("order type: changed, order priority:5", ["changed,", "5"])
+        add_and_test("sometimes one needs multiple words", ["multiple words"], True)
+        add_and_test("sometimes one needs not", ["not"], True)
+        add_and_test("sometimes one needs multiple words", ["multiple words"], True)
+
+    def test_extract_parameters_direct(self):
+        config = TemplateMinerConfig()
+        mi = MaskingInstruction(r"hdfs://[\w.:@-]*((/[\w.~%+-]+)+/?)?", "hdfs_uri")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"(?P<quote>[\"'`]).*?(?P=quote)", "quoted_string")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"((?P<p_0>[*_])\2{0,2}).*?\1", "markdown_emph")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"multiple \*word\* pattern", "*words*")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"some \S+ \S+ pattern", "*words*")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"(\d{1,3}\.){3}\d{1,3}", "ip")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"(?P<number>\d+)\.\d+", "float")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"0[xX][a-fA-F0-9]+", "integer")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"(?P<number>\d+)", "integer")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"HelloWorld", "*")
+        config.masking_instructions.append(mi)
+        mi = MaskingInstruction(r"MaskPrefix", "<")
+        config.masking_instructions.append(mi)
+        template_miner = TemplateMiner(None, config)
+
+        test_vectors = [
+            (
+                "<hdfs_uri>:<integer>+<integer>",
+                "hdfs://msra-sa-41:9000/pageinput2.txt:671088640+134217728",
+                ["hdfs://msra-sa-41:9000/pageinput2.txt", "671088640", "134217728"],
+                ["hdfs_uri", "integer", "integer"]
+            ),
+            (
+                "Hello <quoted_string>",
+                "Hello 'World'",
+                ["'World'"],
+                ["quoted_string"]
+            ),
+            (
+                "<quoted_string><quoted_string>",
+                """'This "should"'`do no breakin'`""",
+                ["""'This "should"'""", "`do no breakin'`"],
+                ["quoted_string", "quoted_string"]
+            ),
+            (
+                "This is <markdown_emph> <markdown_emph>!.",
+                "This is ___very___ *important*!.",
+                ["___very___", "*important*"],
+                ["markdown_emph", "markdown_emph"]
+            ),
+            (
+                "<float>.<*>",
+                "0.15.Test",
+                ["0.15", "Test"],
+                ["float", "*"]
+            ),
+            (
+                "<ip>:<integer>",
+                "192.0.0.1:5000",
+                ["192.0.0.1", "5000"],
+                ["ip", "integer"]
+            ),
+            (
+                "<ip>:<integer>:<integer>",
+                "192.0.0.1:5000:123",
+                ["192.0.0.1", "5000", "123"],
+                ["ip", "integer", "integer"]
+            ),
+            (
+                "<float>.<*>.<float>",
+                "0.15.Test.0.2",
+                ["0.15", "Test", "0.2"],
+                ["float", "*", "float"]
+            ),
+            (
+                "<float> <float>",
+                "0.15 10.16",
+                ["0.15", "10.16"],
+                ["float", "float"]
+            ),
+            (
+                "<*words*>@<integer>",
+                "some other cool pattern@0xe1f",
+                ["some other cool pattern", "0xe1f"],
+                ["*words*", "integer"]
+            ),
+            (
+                "Another test with <*words*> that includes <integer><integer> and <integer> <*> <integer>",
+                "Another test with some other 0Xadded pattern that includes 500xc0ffee and 0X4 times 5",
+                ["some other 0Xadded pattern", "50", "0xc0ffee", "0X4", "times", "5"],
+                ["*words*", "integer", "integer", "integer", "*", "integer"]
+            ),
+            (
+                "some <*words*> <*words*>",
+                "some multiple *word* pattern some confusing *word* pattern",
+                ["multiple *word* pattern", "some confusing *word* pattern"],
+                ["*words*", "*words*"]
+            ),
+            (
+                "<*words*> <*>",
+                "multiple *word* pattern <*words*>",
+                ["multiple *word* pattern", "<*words*>"],
+                ["*words*", "*"]
+            ),
+            (
+                "<*> <*>",
+                "HelloWorld Test",
+                ["HelloWorld", "Test"],
+                ["*", "*"]
+            ),
+            (
+                "<*> <*>",
+                "HelloWorld <anything>",
+                ["HelloWorld", "<anything>"],
+                ["*", "*"]
+            ),
+            (
+                "<*><integer>",
+                "HelloWorld1",
+                ["HelloWorld", "1"],
+                ["*", "integer"]
+            ),
+            (
+                "<*> works <*>",
+                "This works as-expected",
+                ["This", "as-expected"],
+                ["*", "*"]
+            ),
+            (
+                "<memory:<integer>>",
+                "<memory:8>",
+                ["8"],
+                ["integer"]
+            ),
+            (
+                "<memory:<integer> <core:<float>>>",
+                "<memory:8 <core:0.5>>",
+                ["8", "0.5"],
+                ["integer", "float"]
+            ),
+            (
+                "<*> <memory:<<integer> <core:<float>>>",
+                "New: <memory:<8 <core:0.5>>",
+                ["New:", "8", "0.5"],
+                ["*", "integer", "float"]
+            ),
+            (
+                "<<>",
+                "MaskPrefix",
+                ["MaskPrefix"],
+                ["<"]
+            ),
+            (
+                "<<<>>",
+                "<MaskPrefix>",
+                ["MaskPrefix"],
+                ["<"]
+            ),
+            (
+                "There are no parameters here.",
+                "There are no parameters here.",
+                [],
+                []
+            ),
+            (
+                "<float> <float>",
+                "0.15 10.16 3.19",
+                None,
+                None
+            ),
+            (
+                "<float> <float>",
+                "0.15 10.16 test 3.19",
+                None,
+                None
+            ),
+            (
+                "<memory:<<integer> <core:<float>>>",
+                "<memory:8 <core:0.5>>",
+                None,
+                None
+            ),
+            (
+                "<<>",
+                "<<>",
+                None,
+                None
+            ),
+            (
+                "<*words*> <*words*>",
+                "0.15 0.15",
+                None,
+                None
+            ),
+        ]
+
+        for template, content, expected_parameters, expected_mask_names in test_vectors:
+            with self.subTest(template=template, content=content, expected_parameters=expected_parameters):
+                extracted_parameters = template_miner.extract_parameters(template, content, exact_matching=True)
+                if expected_parameters is None:
+                    self.assertIsNone(extracted_parameters)
+                else:
+                    self.assertIsNotNone(extracted_parameters)
+                    self.assertListEqual([parameter.value for parameter in extracted_parameters], expected_parameters)
+                    self.assertListEqual([parameter.mask_name for parameter in extracted_parameters], expected_mask_names)
 
     def test_match_only(self):
         config = TemplateMinerConfig()

--- a/tests/test_template_miner.py
+++ b/tests/test_template_miner.py
@@ -72,8 +72,8 @@ class TemplateMinerTest(unittest.TestCase):
             print(f"msg: {msg}")
             res = template_miner.add_log_message(msg)
             print(f"result: {res}")
-            extracted_parameters = template_miner.extract_parameters(res["template_mined"], msg,
-                                                                     exact_matching=exact_matching)
+            extracted_parameters = template_miner.extract_parameters(
+                res["template_mined"], msg, exact_matching=exact_matching)
             self.assertIsNotNone(extracted_parameters)
             params = [parameter.value for parameter in extracted_parameters]
             print(f"params: {params}")


### PR DESCRIPTION
This is a solution for #49 that will work in most cases.
It works by replacing a mask in the template with the pattern corresponding to that mask.
If there are multiple `MaskingInstruction` with the same `mask_with`-value, their patterns will be seen as alternatives, joined using `|`. In this case, the order of the patterns will be the same as the order of the `MaskingInstruction`-objects, preserving the same machting-priorities.

Because named groups may only be present once in a regex-pattern, the code is a bit more complicated, as named groups need to be renamed to be made unique.

The new method will work best if `mask_with` is unique across all `MaskingInstruction`-objects, because the patterns cannot be confused.
Additionally not using `*` as the value of any `mask_with`, will ensure that only the exact pattern of that `MaskingInstruction` is being matched.
For better performance, any masking pattern should avoid using named groups.

Because the new method may be more performance-heavy, I've introduced a boolean-option to skip some computation steps, which hopefully means it remains comparatively fast. Deactivating `exact_macthing` will be faster, but suffer from the problems laid out in #49.
(Note: In my use-case it slowed down the _overall_ process of parsing and fetching the parameters by a factor of around 2.)
There may be some optimizations one could try to further reduce the performance-impact of the new method I will point out as PR-comments.

This PR includes the extended tests from #51 and adds some of its own.
Feel free to make any changes!

------------

Bonus: As it is useful in my use-case and the overhead for returning the masks is low, 
I've also added a `get_parameter_and_mask_list` method, that returns pairs of parameters and corresponding masks.